### PR TITLE
Threading fixes

### DIFF
--- a/libpinedio-usb.c
+++ b/libpinedio-usb.c
@@ -82,13 +82,14 @@ static int32_t usb_transfer(struct pinedio_inst *inst, const char *func, unsigne
                             const uint8_t *writearr, uint8_t *readarr, bool lock)
 {
   int state_out = TRANS_IDLE;
-  inst->transfer_out->buffer = (uint8_t*)writearr;
-  inst->transfer_out->length = writecnt;
-  inst->transfer_out->user_data = &state_out;
 
   if (lock) {
     pinedio_mutex_lock(&inst->usb_access_mutex);
   }
+
+  inst->transfer_out->buffer = (uint8_t*)writearr;
+  inst->transfer_out->length = writecnt;
+  inst->transfer_out->user_data = &state_out;
 
   /* Schedule write first */
   if (writecnt > 0) {

--- a/libpinedio-usb.c
+++ b/libpinedio-usb.c
@@ -579,7 +579,8 @@ int32_t pinedio_deattach_interrupt(struct pinedio_inst *inst, enum pinedio_int_p
   if (inst->int_running_cnt == 0) {
     inst->pin_poll_thread_exit = true;
     pinedio_mutex_unlock(&inst->usb_access_mutex);
-    pthread_join(inst->pin_poll_thread, NULL);
+    if (inst->pin_poll_thread != pthread_self())
+      pthread_join(inst->pin_poll_thread, NULL);
     return 0;
   }
 unlock:


### PR DESCRIPTION
This is a collection of threading-related fixes I've found. One is a case where a thread tries to call pthread_join on itself, and the other is where shared variables are overwritten prior to a mutex lock.

Fixes #3 